### PR TITLE
Add Endpoint to Retrieve Paginated User Trips

### DIFF
--- a/backend/src/controllers/trip/index.ts
+++ b/backend/src/controllers/trip/index.ts
@@ -13,8 +13,8 @@ export class TripController {
         startDate,
         endDate,
         price,
+        user, // Extracted from auth middleware
       } = req.body;
-      const user = req.body.user; // Extracted from auth middleware
 
       if (
         !title ||
@@ -50,6 +50,34 @@ export class TripController {
     } catch (error) {
       console.error("Error creating trip:", error);
       return res.status(500).json({ message: "Internal server error" });
+    }
+  }
+
+  static async getTrips(req: Request, res: Response) {
+    try {
+      const { user } = req.body;
+
+      const limit = parseInt(req.query.limit as string, 10) || 10;
+      const page = parseInt(req.query.page as string, 10) || 1;
+      const tripRepository = AppDataSource.getRepository(Trip);
+
+      const [trips, total] = await tripRepository.findAndCount({
+        where: {
+          user: { id: user.id },
+        },
+        take: limit,
+        skip: (page - 1) * limit, // skip the previous pages' results
+        order: { createdAt: "DESC" }, // Order by newest trips first
+      });
+
+      return res.status(200).json({
+        trips,
+        total,
+        page,
+        totalPages: Math.ceil(total / limit),
+      });
+    } catch (error) {
+      res.status(500).send({ message: "Internal server error" });
     }
   }
 }

--- a/backend/src/controllers/user/index.ts
+++ b/backend/src/controllers/user/index.ts
@@ -87,7 +87,7 @@ export class UserController {
       // Generate JWT token
       const secretKey = process.env.SECRET_KEY || "This is secret";
       const token = `Bearer ${jwt.sign(
-        { id: user.id, email: user.email },
+        { id: user.id, email: user.email, fullName: user.fullName },
         secretKey
       )}`;
 

--- a/backend/src/docs/routes/tripsDocs.ts
+++ b/backend/src/docs/routes/tripsDocs.ts
@@ -48,3 +48,55 @@
  *       500:
  *         description: Internal server error
  */
+
+/**
+ * @swagger
+ * /api/trips:
+ *   get:
+ *     summary: Retrieve a list of trips for the authenticated user
+ *     tags: [Trips]
+ *     security:
+ *       - BearerAuth: []
+ *     description: Fetch paginated trips belonging to the authenticated user.
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 10
+ *         description: Number of trips per page
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *         description: Page number for pagination
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved trips
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 trips:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Trip'
+ *                 total:
+ *                   type: integer
+ *                   description: Total number of trips
+ *                   example: 25
+ *                 page:
+ *                   type: integer
+ *                   description: Current page number
+ *                   example: 1
+ *                 totalPages:
+ *                   type: integer
+ *                   description: Total number of pages
+ *                   example: 3
+ *       401:
+ *         description: Unauthorized (Invalid or missing token)
+ *       500:
+ *         description: Internal server error
+ */

--- a/backend/src/entities/user.entity.ts
+++ b/backend/src/entities/user.entity.ts
@@ -12,10 +12,10 @@ export class UserEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ type: "varchar", length: 255 })
+  @Column()
   fullName: string;
 
-  @Column({ type: "varchar", length: 255 })
+  @Column()
   password: string;
 
   @Column({ type: "varchar", unique: true })

--- a/backend/src/routes/trips.ts
+++ b/backend/src/routes/trips.ts
@@ -7,5 +7,6 @@ import { asyncHandler } from "./utils";
 const router: Router = Router();
 
 router.post("/", validate(tripSchema), asyncHandler(TripController.createTrip));
+router.get("/", asyncHandler(TripController.getTrips));
 
 export default router;


### PR DESCRIPTION
### Description
This PR introduces a new endpoint to fetch paginated trips for an authenticated user. It supports pagination and returns trips ordered by creation date in descending order.

### Changes Implemented
- Created `GET /api/trips` endpoint to retrieve trips associated with the authenticated user.
- Added pagination support using `limit` and `page` query parameters.
- Sorted trips in descending order based on `createdAt`.
- Included response metadata: total trips, current page, and total pages.
- Improved error handling to return appropriate status codes.

### API Documentation
- Endpoint: `GET /api/trips`
### Query Parameters:

- `limit` (optional, default: `10`): Number of trips per page.
- `page` (optional, default: `1`): Page number to retrieve.

### Response Example:
```
{
  "trips": [
    {
      "id": 1,
      "title": "Beach Vacation",
      "destination": "Maldives",
      "startDate": "2025-06-01",
      "endDate": "2025-06-10",
      "price": 1500.00
    }
  ],
  "total": 5,
  "page": 1,
  "totalPages": 1
}
```
### How to Test
- Authenticate a user and obtain a valid token.
- Make a `GET` request to `/api/trips` with the token in the Authorization header.
- Optionally, pass `limit` and `page` query parameters to test pagination.