### PR TITLE
feat: Implement delete trip endpoint

### DIFF
--- a/backend/src/controllers/trip/index.ts
+++ b/backend/src/controllers/trip/index.ts
@@ -168,4 +168,34 @@ export class TripController {
       });
     }
   }
+
+  static async deleteTrip(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const { user } = req.body;
+      const tripRepository = AppDataSource.getRepository(Trip);
+
+      // Find the trip
+      const trip = await tripRepository.findOne({
+        where: {
+          id: parseInt(id, 10),
+          user: { id: user.id }, // can only delete a trip you own
+        },
+      });
+
+      if (!trip) {
+        return res.status(404).json({ message: "Trip not found" });
+      }
+
+      // Delete the trip
+      await tripRepository.remove(trip);
+
+      return res.status(200).json({
+        message: "Trip deleted successfully",
+      });
+    } catch (error) {
+      console.error("Error deleting trip:", error);
+      return res.status(500).json({ message: "Internal server error" });
+    }
+  }
 }

--- a/backend/src/docs/routes/trips/delete.ts
+++ b/backend/src/docs/routes/trips/delete.ts
@@ -1,0 +1,26 @@
+/**
+ * @swagger
+ * /api/trips/{id}:
+ *   delete:
+ *     summary: Delete your own existing trip
+ *     tags: [Trips]
+ *     security:
+ *       - BearerAuth: []
+ *     description: Allows authenticated users to delete a trip.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: The ID of the trip to update
+ *     responses:
+ *       200:
+ *         description: Trip deleted successfully
+ *       401:
+ *         description: Unauthorized (No token or invalid token)
+ *       404:
+ *         description: Trip not found
+ *       500:
+ *         description: Internal server error
+ */

--- a/backend/src/routes/trips.ts
+++ b/backend/src/routes/trips.ts
@@ -14,5 +14,6 @@ router.patch(
   validate(updateTripSchema),
   asyncHandler(TripController.editTrip)
 );
+router.delete("/:id", asyncHandler(TripController.deleteTrip));
 
 export default router;


### PR DESCRIPTION
### Description:
This PR adds functionality to delete a trip by its ID. The following changes have been made:
- Implemented the deleteTrip method in the Trip controller.
- Validates if the trip exists and that it belongs to authenticated user before attempting deletion.
- Uses TypeORM's remove() method to delete the trip.
- Returns appropriate responses for success, not found, and server errors.
- Secures the endpoint with authentication middleware.

### How to Test
- Send a `DELETE` request to `/api/trips/:id` with a valid trip ID.
- Ensure the trip is removed from the database.
- If the trip ID does not exist, the response should be a 404 Not Found.
- If an unauthorized request is made, it should return a 401 Unauthorized.