### PR TITLE
Implement Trip Filtering with Authentication

### DIFF
--- a/backend/src/config/data-source.ts
+++ b/backend/src/config/data-source.ts
@@ -19,8 +19,7 @@ export const AppDataSource = new DataSource({
   database: dbName, // Database name
 
   synchronize: true, // Auto-syncs schema; set to false in production to avoid data loss
-  logging: true, // Enables SQL query logging (set to false in production)
-
+  logging: false,
   entities: [UserEntity, Trip], // Specifies entity files to be used by TypeORM
   migrations: ["@/migrations/*.ts"], // Path to migration files (Adjust as needed)
   subscribers: [], // No subscribers defined for now

--- a/backend/src/docs/routes/trips/filter.ts
+++ b/backend/src/docs/routes/trips/filter.ts
@@ -1,0 +1,88 @@
+/**
+ * @swagger
+ * /api/trips/filter:
+ *   get:
+ *     summary: Filter trips based on criteria
+ *     tags: [Trips]
+ *     security:
+ *       - BearerAuth: []
+ *     description: Retrieve trips based on filters such as origin, destination, start date, end date, and price range.
+ *     parameters:
+ *       - in: query
+ *         name: origin
+ *         schema:
+ *           type: string
+ *         description: Filter trips by origin (case insensitive)
+ *         example: "New York"
+ *       - in: query
+ *         name: destination
+ *         schema:
+ *           type: string
+ *         description: Filter trips by destination (case insensitive)
+ *         example: "Maldives"
+ *       - in: query
+ *         name: startDate
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: Filter trips that start on or after this date
+ *         example: "2025-06-01"
+ *       - in: query
+ *         name: endDate
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: Filter trips that end on or before this date
+ *         example: "2025-06-10"
+ *       - in: query
+ *         name: minPrice
+ *         schema:
+ *           type: number
+ *         description: Minimum price filter
+ *         example: 100
+ *       - in: query
+ *         name: maxPrice
+ *         schema:
+ *           type: number
+ *         description: Maximum price filter
+ *         example: 5000
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *         description: Pagination - page number
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 10
+ *         description: Pagination - number of results per page
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved filtered trips
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 trips:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Trip'
+ *                 total:
+ *                   type: integer
+ *                   description: Total number of matching trips
+ *                 page:
+ *                   type: integer
+ *                   description: Current page number
+ *                 totalPages:
+ *                   type: integer
+ *                   description: Total number of pages
+ *       400:
+ *         description: Bad request (invalid query parameters)
+ *       401:
+ *         description: Unauthorized (No token or invalid token)
+ *       500:
+ *         description: Internal server error
+ */

--- a/backend/src/routes/trips.ts
+++ b/backend/src/routes/trips.ts
@@ -7,8 +7,11 @@ import { asyncHandler } from "./utils";
 const router: Router = Router();
 
 router.post("/", validate(tripSchema), asyncHandler(TripController.createTrip));
+
+router.get("/filter", asyncHandler(TripController.filterTrips));
 router.get("/", asyncHandler(TripController.getTrips));
 router.get("/:id", asyncHandler(TripController.getTrips));
+
 router.patch(
   "/:id",
   validate(updateTripSchema),


### PR DESCRIPTION
This PR introduces an authenticated trip filtering endpoint, allowing users to filter trips based on various criteria.

### Key Changes:
- Added an endpoint to filter trips by:
   - `origin`
   - `destination`
   - `startDate` and `endDate` range
   - `price range`
- Implemented authentication protection using a bearer token
- Added pagination support for better query efficiency
- Improved error handling for invalid or missing parameters
- Added comprehensive Swagger documentation for the endpoint

### How to Test:
- Authenticate with a valid token.
- Send a `GET` request to `/api/trips/filter` with query parameters (e.g., ?`origin=Nairobi&destination=Paris&minPrice=500&maxPrice=2000`).
- Verify that only matching trips are returned based on the filters.