### PR TITLE
Add Delete Functionality for Trips

### DIFF
--- a/frontend/src/components/trips/TripCard.vue
+++ b/frontend/src/components/trips/TripCard.vue
@@ -15,18 +15,42 @@
             {{ formatDate(trip.endDate) }}</span
           >
         </p>
-        <p class="text-xl font-bold text-green-600 mt-2">${{ trip.price }}</p>
+        <div class="flex items-center mt-2 justify-between">
+          <p class="text-xl font-bold text-green-600">${{ trip.price }}</p>
+          <button
+            @click="handleDelete(trip.id)"
+            class="ml-2 text-red-500 cursor-pointer hover:text-red-700 transition"
+          >
+            <TrashIcon class="w-5 h-5" />
+          </button>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
+import { useTripsStore } from "@/stores/tripStore";
+import { Trash2 as TrashIcon } from "lucide-vue-next";
+import { toast } from "vue3-toastify";
+
 const props = defineProps(["trip"]);
+const { deleteTrip } = useTripsStore();
+
 const formatDate = (date) =>
   new Date(date).toLocaleDateString("en-US", {
     year: "numeric",
     month: "long",
     day: "numeric",
   });
+
+const handleDelete = async (id) => {
+  try {
+    await deleteTrip(id);
+    toast.success("Trip deleted successfully", { autoClose: 3000 });
+  } catch (error) {
+    toast.error("Failed to delete trip", { autoClose: 3000 });
+    console.error(error);
+  }
+};
 </script>


### PR DESCRIPTION
**Description**
This PR adds the ability to delete a trip from the trip list. A small delete icon (trash can) is added next to the trip price, allowing users to remove a trip.

**Changes Introduced**
- Added a delete button (trash icon) to the trip card
- Integrated deleteTrip function from the store
- Displayed success/error toast notifications upon deletion

**How to Test**
- Navigate to the trips list page.
- Locate a trip and click on the delete (trash) icon.
- Confirm that the trip is removed from the UI.
- Check toast notifications for success or error messages.