### PR TITLE
Integrate API Pagination for Trip Listing

### DIFF
--- a/frontend/src/components/trips/TripGrid.vue
+++ b/frontend/src/components/trips/TripGrid.vue
@@ -24,14 +24,14 @@
       v-if="trips.trips.length > 0"
       class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-10"
     >
-      <TripCard v-for="trip in paginatedTrips" :key="trip.id" :trip="trip" />
+      <TripCard v-for="trip in trips.trips" :key="trip.id" :trip="trip" />
     </div>
 
     <!-- Pagination -->
     <Pagination
-      v-if="trips.trips.length > itemsPerPage"
+      v-if="trips.total > itemsPerPage"
       :currentPage="currentPage"
-      :totalItems="trips.trips.length"
+      :totalPages="trips.totalPages"
       :itemsPerPage="itemsPerPage"
       @page-change="handlePageChange"
     />
@@ -46,7 +46,7 @@
 <script setup>
 import { useModalStore } from "@/stores/modalStore";
 import { useTripsStore } from "@/stores/tripStore";
-import { computed, onMounted, ref } from "vue";
+import { onMounted, ref } from "vue";
 import Loader from "../ui/Loader.vue";
 import Pagination from "../ui/Pagination.vue";
 import TripCard from "./TripCard.vue";
@@ -57,16 +57,14 @@ const { openModal, isOpen } = useModalStore();
 const currentPage = ref(1);
 const itemsPerPage = 8;
 
-onMounted(() => {
-  getTrips();
+// Fetch trips when the component mounts
+onMounted(async () => {
+  await getTrips(currentPage.value, itemsPerPage);
 });
 
-const paginatedTrips = computed(() => {
-  const start = (currentPage.value - 1) * itemsPerPage;
-  return trips.trips.slice(start, start + itemsPerPage);
-});
-
-const handlePageChange = (page) => {
+// Fetch trips when a new page is selected
+const handlePageChange = async (page) => {
   currentPage.value = page;
+  await getTrips(page, itemsPerPage);
 };
 </script>

--- a/frontend/src/components/ui/Pagination.vue
+++ b/frontend/src/components/ui/Pagination.vue
@@ -4,7 +4,7 @@
     <button
       @click="changePage(currentPage - 1)"
       :disabled="currentPage === 1"
-      class="px-3 py-2 text-sm bg-gray-200 rounded disabled:opacity-50"
+      class="px-3 py-2 cursor-pointer text-sm bg-gray-200 rounded disabled:opacity-50"
     >
       Previous
     </button>
@@ -16,7 +16,9 @@
       @click="changePage(page)"
       :class="[
         'px-3 py-2 text-sm rounded',
-        page === currentPage ? 'bg-blue-500 text-white' : 'bg-gray-200'
+        page === currentPage
+          ? 'cursor-pointer bg-blue-500 text-white'
+          : 'bg-gray-200',
       ]"
     >
       {{ page }}
@@ -26,7 +28,7 @@
     <button
       @click="changePage(currentPage + 1)"
       :disabled="currentPage === totalPages"
-      class="px-3 py-2 text-sm bg-gray-200 rounded disabled:opacity-50"
+      class="px-3 py-2 cursor-pointer disabled:cursor-not-allowed text-sm bg-gray-200 rounded disabled:opacity-50"
     >
       Next
     </button>
@@ -34,20 +36,18 @@
 </template>
 
 <script setup>
-import { defineProps, defineEmits, computed } from "vue";
+import { defineEmits, defineProps } from "vue";
 
 const props = defineProps({
   currentPage: Number,
-  totalItems: Number,
+  totalPages: Number,
   itemsPerPage: { type: Number, default: 5 },
 });
 
 const emit = defineEmits(["page-change"]);
 
-const totalPages = computed(() => Math.ceil(props.totalItems / props.itemsPerPage));
-
 const changePage = (page) => {
-  if (page >= 1 && page <= totalPages.value) {
+  if (page >= 1 && page <= props.totalPages) {
     emit("page-change", page);
   }
 };

--- a/frontend/src/stores/tripStore.js
+++ b/frontend/src/stores/tripStore.js
@@ -20,10 +20,11 @@ export const useTripsStore = defineStore("trips", () => {
   });
 
   // Fetch trips
-  const getTrips = async () => {
+  const getTrips = async (page, limit) => {
     try {
       isLoading.value = true;
-      const data = await fetchWithAuth(`trips`);
+      const url = `trips?page=${page}&limit=${limit}`;
+      const data = await fetchWithAuth(url);
       Object.assign(trips, data);
     } catch (err) {
       trips.error.message = err.message;


### PR DESCRIPTION
**Description**
This PR updates the trip listing pagination to fetch data from the API when a page is selected. Previously, pagination was handled on the frontend without making API requests.

**Changes Made**
- Updated getTrips to accept currentPage and itemsPerPage parameters.
- Modified pagination logic to trigger an API call when a page is clicked.
- Ensured proper state management for currentPage to prevent incorrect data rendering.

**How to Test**
- Run the application and navigate to the trip listing page.
- Click on different page numbers in the pagination component.
- Verify that only the trips for the selected page are displayed.
- Ensure no duplicate or missing data when switching pages.